### PR TITLE
actions: automatically add all opened issues and PRs to project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add issues and PRs to project boards
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+permissions: read-all
+
+jobs:
+  add-to-project-boards:
+    uses: osism/.github/.github/workflows/add-to-project.yml@main
+    secrets: inherit


### PR DESCRIPTION
* reuse workflow from osism/.github/.github/workflows/add-to-project.yml to add Issues and PRs to project boards

_Mirrors osism/release#2483 (6234b559)._